### PR TITLE
Add Loki Dashboards

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,6 +16,12 @@ They can be imported into Grafana by clicking Import and pasting the JSON into t
 | Blackbox Exporter Overview | generated | N/A      |              |
 | Dnsmasq Overview           | generated | N/A      |              |
 | Docker Overview            | generated | N/A      |              |
+| Loki / Chunks              | modified  | [Loki Mixin](https://github.com/grafana/loki/tree/main/production/loki-mixin) | Modified original mixin using jsonnet to suit my needs |
+| Loki / Deletion            | modified  | [Loki Mixin](https://github.com/grafana/loki/tree/main/production/loki-mixin) | Modified original mixin using jsonnet to suit my needs |
+| Loki / Operation           | modified  | [Loki Mixin](https://github.com/grafana/loki/tree/main/production/loki-mixin) | TODO         |
+| Loki / Reads               | modified  | [Loki Mixin](https://github.com/grafana/loki/tree/main/production/loki-mixin) | Modified original mixin using jsonnet to suit my needs |
+| Loki / Retention           | modified  | [Loki Mixin](https://github.com/grafana/loki/tree/main/production/loki-mixin) | Modified original mixin using jsonnet to suit my needs |
+| Loki / Writes              | modified  | [Loki Mixin](https://github.com/grafana/loki/tree/main/production/loki-mixin) | Modified original mixin using jsonnet to suit my needs |
 | Node Exporter              | modified  | [Node Exporter](https://github.com/rfmoz/grafana-dashboards/blob/master/prometheus/node-exporter-full.json) | Added disk labels. Modified from original using jsonnet |
 | Prometheus / Overview      | modified  | [Prometheus Mixin](https://github.com/prometheus/prometheus/blob/main/documentation/prometheus-mixin/dashboards.libsonnet) | Original jsonnet is modified to suit my needs and uses the Grafonnet library |
 | Prometheus / Remote Write  | modified  | [Prometheus Mixin](https://github.com/prometheus/prometheus/blob/main/documentation/prometheus-mixin/dashboards.libsonnet) | Original jsonnet is modified to suit my needs and uses the Grafonnet library |

--- a/generate.jsonnet
+++ b/generate.jsonnet
@@ -19,6 +19,7 @@
 (import 'jsonnet-dashboards/dnsmasq-overview/main.libsonnet') +
 (import 'jsonnet-dashboards/docker-overview/main.libsonnet') +
 (import 'jsonnet-dashboards/grafana-agent/main.libsonnet') +
+(import 'jsonnet-dashboards/loki/main.libsonnet') +
 (import 'jsonnet-dashboards/prometheus/main.libsonnet') +
 (import 'jsonnet-dashboards/node-exporter/main.libsonnet') +
 (import 'jsonnet-dashboards/smart-overview/main.libsonnet') +

--- a/jsonnet-dashboards/loki/config.libsonnet
+++ b/jsonnet-dashboards/loki/config.libsonnet
@@ -47,6 +47,12 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
     ],
 
   loki: {
+    _config+:: {
+      promtail: {
+        enabled: false,
+      }
+    },
+
     grafanaDashboards+: {
       'loki-chunks.json'+: {
         labelsSelector:: 'cluster=~"$cluster", namespace=~"$namespace", job=~"($namespace)/loki"',
@@ -90,8 +96,53 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
         // - Fix last few panels in dashboard
       },
 
-      // TODO
+      // TODO: Fix this to work. We may need to create our own dashboard based on theirs as it isn't very easy to modify
       'loki-operational.json'+: {
+        hiddenRows:: [
+          'Cassandra',
+          'GCS',
+          'Memcached',
+          'Consul',
+          'Big Table',
+          'Dynamo',
+          'Azure Blob',
+          'BoltDB Shipper',
+        ],
+
+        jobMatchers:: {
+          cortexgateway:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+          distributor:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+          ingester:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+          querier:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+          queryFrontend:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+        },
+
+        uid: '',
+        time: {
+          from: 'now-6h',
+          to: 'now'
+        },
+        refresh: '1m',
+        timezone: '',
+
+        templating+: {
+          list: mapTemplateParameters(super.list),
+        }
       },
 
       'loki-reads.json'+: {

--- a/jsonnet-dashboards/loki/config.libsonnet
+++ b/jsonnet-dashboards/loki/config.libsonnet
@@ -131,8 +131,42 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
       'loki-retention.json'+: {
       },
 
-      // TODO
       'loki-writes.json'+: {
+        local dropList = ['Distributor - Structured Metadata', 'Ingester - Zone Aware', 'BoltDB Shipper'],
+
+        matchers:: {
+          cortexgateway:: [],
+          distributor:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+          ingester:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+          ingester_zone:: [],
+          any_ingester:: [
+            utils.selector.re('namespace', '$namespace'),
+            utils.selector.re('job', '($namespace)/loki'),
+          ],
+        },
+
+        uid: '',
+        time: {
+          from: 'now-6h',
+          to: 'now'
+        },
+        refresh: '1m',
+        timezone: '',
+
+        rows: dropPanels(super.rows, dropList),
+
+        templating+: {
+          list: mapTemplateParameters(super.list),
+        }
+
+        // TODO
+        // - Update rules to get latency working correctly
       },
     }
   }

--- a/jsonnet-dashboards/loki/config.libsonnet
+++ b/jsonnet-dashboards/loki/config.libsonnet
@@ -30,6 +30,7 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
     } else {}
   ),
 
+  // dropPanels removes unnecessary panels from the loki dashboards
   local dropPanels = function(panels, dropList)
     [
       p
@@ -37,6 +38,8 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
       if !std.member(dropList, p.title)
     ],
 
+  // mapTemplateParameters applies a static list of transformer functions to
+  // all dashboard template parameters.
   local mapTemplateParameters = function(ls)
     [
       std.foldl(function(x, fn) fn(x), [withMultiSelectTemplate], item)
@@ -127,8 +130,25 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
         // - Change Per Pod Latency to per instance
       },
 
-      // TODO
       'loki-retention.json'+: {
+        local dropList = ['Resource Usage'],
+
+        uid: '',
+        time: {
+          from: 'now-6h',
+          to: 'now'
+        },
+        refresh: '1m',
+        timezone: '',
+
+        rows: dropPanels(super.rows, dropList),
+
+        templating+: {
+          list: mapTemplateParameters(super.list),
+        }
+
+        // TODO
+        // - Work out if we should drop the retention row
       },
 
       'loki-writes.json'+: {

--- a/jsonnet-dashboards/loki/config.libsonnet
+++ b/jsonnet-dashboards/loki/config.libsonnet
@@ -130,7 +130,7 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
       },
 
       // TODO: Fix this to work. We may need to create our own dashboard based on theirs as it isn't very easy to modify
-      'loki-operational.json'+: {
+      /*'loki-operational.json'+: {
         hiddenRows:: [
           'Cassandra',
           'GCS',
@@ -161,7 +161,7 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
         templating+: {
           list: mapTemplateParameters(super.list),
         }
-      },
+      },*/
 
       'loki-reads.json'+: {
         local dropList = ['Frontend (query-frontend)', 'Ingester - Zone Aware', 'BoltDB Shipper'],

--- a/jsonnet-dashboards/loki/dashboard.libsonnet
+++ b/jsonnet-dashboards/loki/dashboard.libsonnet
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Ashley Lavery
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+local config = (import 'config.libsonnet');
+local loki = (import 'github.com/grafana/loki/production/loki-mixin/mixin.libsonnet') + config.loki;
+
+{
+  'loki-chunks.json': loki.grafanaDashboards['loki-chunks.json'],
+  'loki-deletion.json': loki.grafanaDashboards['loki-deletion.json'],
+  'loki-operational.json': loki.grafanaDashboards['loki-operational.json'],
+  'loki-reads.json': loki.grafanaDashboards['loki-reads.json'],
+  'loki-retention.json': loki.grafanaDashboards['loki-retention.json'],
+  'loki-writes.json': loki.grafanaDashboards['loki-writes.json'],
+}

--- a/jsonnet-dashboards/loki/main.libsonnet
+++ b/jsonnet-dashboards/loki/main.libsonnet
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Ashley Lavery
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(import 'dashboard.libsonnet')

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -9,6 +9,15 @@
         }
       },
       "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/loki-mixin"
+        }
+      },
+      "version": "main"
     }
   ],
   "legacyImports": true

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -38,7 +38,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "02db06f540086fa3f67d487bd01e1b314853fb8f",
+      "version": "a546eec7cbb119d11c69911ae85bb8b43be07f6a",
       "sum": "B49EzIY2WZsFxNMJcgRxE/gcZ9ltnS8pkOOV6Q5qioc="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "02db06f540086fa3f67d487bd01e1b314853fb8f",
+      "version": "a546eec7cbb119d11c69911ae85bb8b43be07f6a",
       "sum": "PGf+vyCHqGxxS6SKNZiN3vR1xPnw6VOESXbeJrA5FaA="
     },
     {
@@ -58,8 +58,8 @@
           "subdir": "production/loki-mixin"
         }
       },
-      "version": "afe146c88445b046d7fd2ac7e98ad490dda51018",
-      "sum": "IohgLDbRoSrvwmtvd5WkZjf06TxJDvEBSjlp+1s4VDg="
+      "version": "0065fd6e95fc7531abf3d3d8aab33ec0f8aeea8f",
+      "sum": "Pw/9T/ZRjXLqTivU5xkJnrP5kFdET2FDUjjG1G96GmQ="
     },
     {
       "source": {
@@ -68,8 +68,8 @@
           "subdir": "operations/mimir-mixin"
         }
       },
-      "version": "297e905ce8bb86382b5c50f9abbcf335e2b22244",
-      "sum": "TBKoXovJMzJ5M6vCrj1zser5ljWYuYXNy/IoUOZ3S/c="
+      "version": "7ce863f254818aaf33e1dbc3a1bd74dc92554f14",
+      "sum": "ZwiZFnW1zA9lh++91npc3DkgBF1hBV3AEOnkVXrl9W0="
     },
     {
       "source": {
@@ -98,7 +98,7 @@
           "subdir": "jsonnet/kube-prometheus/lib"
         }
       },
-      "version": "0cf56a9fb60a30102fb549add8afaa8d4e2e89ec",
+      "version": "e7fa2f0b3c7606296dba118cc1759e8055f7215b",
       "sum": "QKRgrgEZ3k9nLmLCrDBaeIGVqQZf+AvZTcnhdLk3TrA="
     }
   ],

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -4,6 +4,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "a1d61cce1da59c71409b99b5c7568511fec661ea",
+      "sum": "342u++/7rViR/zj2jeJOjshzglkZ1SY+hFNuyCBFMdc="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
           "subdir": "gen/grafonnet-latest"
         }
@@ -24,6 +34,46 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "02db06f540086fa3f67d487bd01e1b314853fb8f",
+      "sum": "B49EzIY2WZsFxNMJcgRxE/gcZ9ltnS8pkOOV6Q5qioc="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "mixin-utils"
+        }
+      },
+      "version": "02db06f540086fa3f67d487bd01e1b314853fb8f",
+      "sum": "PGf+vyCHqGxxS6SKNZiN3vR1xPnw6VOESXbeJrA5FaA="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/loki-mixin"
+        }
+      },
+      "version": "afe146c88445b046d7fd2ac7e98ad490dda51018",
+      "sum": "IohgLDbRoSrvwmtvd5WkZjf06TxJDvEBSjlp+1s4VDg="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/mimir.git",
+          "subdir": "operations/mimir-mixin"
+        }
+      },
+      "version": "297e905ce8bb86382b5c50f9abbcf335e2b22244",
+      "sum": "TBKoXovJMzJ5M6vCrj1zser5ljWYuYXNy/IoUOZ3S/c="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/jsonnet-libs/docsonnet.git",
           "subdir": "doc-util"
         }
@@ -40,6 +90,16 @@
       },
       "version": "c1a315a7dbead0335a5e0486acc5583395b22a24",
       "sum": "UVdL+uuFI8BSQgLfMJEJk2WDKsQXNT3dRHcr2Ti9rLI="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/prometheus-operator/kube-prometheus.git",
+          "subdir": "jsonnet/kube-prometheus/lib"
+        }
+      },
+      "version": "0cf56a9fb60a30102fb549add8afaa8d4e2e89ec",
+      "sum": "QKRgrgEZ3k9nLmLCrDBaeIGVqQZf+AvZTcnhdLk3TrA="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This pull request adds the required jsonnet to transform the default [loki mixin](https://github.com/grafana/loki/blob/main/production/loki-mixin) to a format that will work with my environment

Dashboards:
- [x] Loki / Chunks
- [x] Loki / Deletion
- [ ] ~~Loki / Operational~~
- [x] Loki / Reads
- [x] Loki / Retention
- [x] Loki / Writes